### PR TITLE
Write parser_table_py to a different location.

### DIFF
--- a/yaql/parser.py
+++ b/yaql/parser.py
@@ -206,7 +206,7 @@ precedence = (
     ('left', 'SYMBOL')
 )
 
-parser = yacc.yacc(debug=False, outputdir='./yaql', tabmodule='parser_table')
+parser = yacc.yacc(debug=False, outputdir='/tmp', tabmodule='parser_table')
 
 
 def parse(expression):


### PR DESCRIPTION
./yaql does not always exist or writable.
