### PR TITLE
Fix issue with fixed name for parser tables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup, find_packages
 
 setup(name='yaql',
-      version='0.2.3',
+      version='0.2.4',
       description="Yet Another Query Language",
       author='Mirantis, Inc.',
       author_email='info@mirantis.com',

--- a/yaql/__init__.py
+++ b/yaql/__init__.py
@@ -16,12 +16,14 @@ import parser
 import context
 from yaql.functions import builtin, extended
 
-__versioninfo__ = (0, 2, 3)
+__versioninfo__ = (0, 2, 4)
 __version__ = '.'.join(map(str, __versioninfo__))
+__grammar_version__ = '1.0'
 
 
-def parse(expression):
-    return parser.parse(expression)
+def parse(expression, write_tables=False):
+    tabmodule = 'yaql_parser_t_v%s' % __grammar_version__
+    return parser.parse(expression, write_tables, tabmodule)
 
 
 def create_context(include_extended_functions=True):

--- a/yaql/cli/run.py
+++ b/yaql/cli/run.py
@@ -23,6 +23,7 @@ from yaql.cli import cli_functions
 def main():
     p = optparse.OptionParser()
     p.add_option('--data', '-d')
+    p.add_option('--no-parser-table', '-t')
     options, arguments = p.parse_args()
     if options.data:
         try:
@@ -35,9 +36,10 @@ def main():
     else:
         data = None
 
+    write_tables = True if options.no_parser_table else False
     context = yaql.create_context()
     cli_functions.register_in_context(context)
-    yaql.parse('__main()').evaluate(data, context)
+    yaql.parse('__main()', write_tables=write_tables).evaluate(data, context)
 
 
 if __name__ == "__main__":

--- a/yaql/parser.py
+++ b/yaql/parser.py
@@ -13,11 +13,14 @@
 #    under the License.
 
 import types
+import tempfile
+import uuid
+
 import ply.yacc as yacc
+
 import expressions
 import exceptions
 import lexer
-import tempfile
 
 
 tokens = lexer.tokens
@@ -207,8 +210,16 @@ precedence = (
     ('left', 'SYMBOL')
 )
 
-parser = yacc.yacc(debug=False, outputdir=tempfile.gettempdir(), tabmodule='parser_table')
+parser = None
 
 
-def parse(expression):
+def parse(expression, write_tables=False, tabmodule=None):
+    global parser
+    if parser is None:
+        parser = yacc.yacc(
+            debug=False,
+            outputdir=tempfile.gettempdir(),
+            write_tables=(1 if not write_tables else 0),
+            tabmodule=tabmodule or 'yaql_%s' % uuid.uuid4().hex
+        )
     return parser.parse(expression)


### PR DESCRIPTION
- Introduced grammar version
- Bumped yaql version to 0.2.4
- Name for temporary file for parser tables
  is now based on grammar version
- Added option to disable storing parser table
  to temporary file
